### PR TITLE
Add short_url method to ShortenedOffers

### DIFF
--- a/app/models/shortened_url.rb
+++ b/app/models/shortened_url.rb
@@ -5,6 +5,10 @@ class ShortenedUrl < ApplicationRecord
 
   validates :uid, :original_url, presence: true
 
+  def short_url
+    @short_url ||= ENV['SERVICE_URL'] + uid
+  end
+
   private
 
   def init_uid

--- a/config/application.rb
+++ b/config/application.rb
@@ -14,6 +14,13 @@ module App
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.1
 
+    config.before_configuration do
+      env_file = File.join(Rails.root, 'config', 'environment.yml')
+      YAML.safe_load(File.open(env_file)).fetch(Rails.env, {}).each do |key, value|
+        ENV[key.to_s] = value
+      end
+    end
+
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files

--- a/config/environment.yml
+++ b/config/environment.yml
@@ -1,0 +1,5 @@
+development:
+  SERVICE_URL: "localhost:3000/"
+
+test:
+  SERVICE_URL: "small.url/"

--- a/spec/models/shortened_url_spec.rb
+++ b/spec/models/shortened_url_spec.rb
@@ -32,4 +32,12 @@ RSpec.describe ShortenedUrl, type: :model do
     it { is_expected.to validate_presence_of :uid }
     it { is_expected.to validate_presence_of :original_url }
   end
+
+  describe '#short_url' do
+    subject { create(:shortened_url, uid: 'abc-123').short_url }
+
+    it 'returns the expected url containing the uid' do
+      expect(subject).to eq('small.url/abc-123')
+    end
+  end
 end


### PR DESCRIPTION
This will be used to create the URL users can use to link to the
    original link they provide.

Add simple environment.yml input on app start. This uses the current rails environment to select the appropriate part
    of the yml file and then loads all the values into ENV. This will be
    used shortly to generate the appropriate short_url on the ShortenedUrl
    model.