### PR TITLE
Only permit the original_url to be set on create

### DIFF
--- a/app/controllers/shortened_urls_controller.rb
+++ b/app/controllers/shortened_urls_controller.rb
@@ -46,7 +46,7 @@ class ShortenedUrlsController < ApplicationController
 
   # Only allow a list of trusted parameters through.
   def shortened_url_params
-    params.require(:shortened_url).permit(:uid, :original_url, :redirect_count)
+    params.require(:shortened_url).permit(:original_url)
   end
 
   def redirect_and_increment_counter

--- a/app/views/shortened_urls/_form.html.erb
+++ b/app/views/shortened_urls/_form.html.erb
@@ -12,18 +12,8 @@
   <% end %>
 
   <div class="field">
-    <%= form.label :uid %>
-    <%= form.text_field :uid %>
-  </div>
-
-  <div class="field">
     <%= form.label :original_url %>
     <%= form.text_field :original_url %>
-  </div>
-
-  <div class="field">
-    <%= form.label :redirect_count %>
-    <%= form.number_field :redirect_count %>
   </div>
 
   <div class="actions">

--- a/spec/requests/shortened_urls/create_spec.rb
+++ b/spec/requests/shortened_urls/create_spec.rb
@@ -4,29 +4,59 @@ require 'rails_helper'
 
 RSpec.describe '/shortened_urls', type: :request do
   describe 'POST /create' do
-    context 'with valid parameters' do
-      let(:valid_params) do
-        {
-          shortened_url: {
-            original_url: 'https://example.com'
-          }
+    subject { post shortened_urls_url, params: params }
+    let(:params) do
+      {
+        shortened_url: {
+          original_url: 'https://example.com'
         }
-      end
+      }
+    end
+
+    context 'with valid parameters' do
+      let(:shortened_url_created) { ShortenedUrl.last }
 
       it 'creates a new ShortenedUrl' do
-        expect do
-          post shortened_urls_url, params: valid_params
-        end.to change(ShortenedUrl, :count).by(1)
+        expect { subject }.to change(ShortenedUrl, :count).by(1)
       end
 
       it 'redirects to the created shortened_url' do
-        post shortened_urls_url, params: valid_params
-        expect(response).to redirect_to(shortened_url_url(ShortenedUrl.last))
+        subject
+
+        expect(response).to redirect_to(
+          shortened_url_url(shortened_url_created)
+        )
+      end
+
+      it 'sets the expected shortened_url attributes' do
+        subject
+
+        expect(shortened_url_created.original_url).to eq 'https://example.com'
+        expect(shortened_url_created.redirect_count).to eq 0
+      end
+
+      context 'with uid and redirect_count given' do
+        let(:params) do
+          {
+            shortened_url: {
+              original_url: 'https://example.com',
+              uid: 'uid-given',
+              redirect_count: '77'
+            }
+          }
+        end
+
+        it 'does not use the uid or redirect_count given' do
+          subject
+
+          expect(shortened_url_created.redirect_count).to eq 0
+          expect(shortened_url_created.uid).to_not eq 77
+        end
       end
     end
 
     context 'with invalid parameters' do
-      let(:invalid_params) do
+      let(:params) do
         {
           shortened_url: {
             someting_random: true
@@ -35,13 +65,12 @@ RSpec.describe '/shortened_urls', type: :request do
       end
 
       it 'does not create a new ShortenedUrl' do
-        expect do
-          post shortened_urls_url, params: invalid_params
-        end.to change(ShortenedUrl, :count).by(0)
+        expect { subject }.to change(ShortenedUrl, :count).by(0)
       end
 
       it 'renders an unsuccessful response' do
-        post shortened_urls_url, params: invalid_params
+        subject
+
         expect(response).to_not be_successful
       end
     end

--- a/spec/views/shortened_urls/new.html.erb_spec.rb
+++ b/spec/views/shortened_urls/new.html.erb_spec.rb
@@ -15,11 +15,16 @@ RSpec.describe 'shortened_urls/new', type: :view do
     render
 
     assert_select 'form[action=?][method=?]', shortened_urls_path, 'post' do
-      assert_select 'input[name=?]', 'shortened_url[uid]'
-
       assert_select 'input[name=?]', 'shortened_url[original_url]'
 
-      assert_select 'input[name=?]', 'shortened_url[redirect_count]'
+      assert_select 'input[name=?]',
+                    'shortened_url[uid]',
+                    false,
+                    'The uid must be auto-generated'
+      assert_select 'input[name=?]',
+                    'shortened_url[redirect_count]',
+                    false,
+                    'The redirect_count must be auto-generated'
     end
   end
 end


### PR DESCRIPTION
The uid and redirect_url must be automatically generated.