### PR TITLE
Show short_url in favour of uid on index and show pages

### DIFF
--- a/app/views/shortened_urls/index.html.erb
+++ b/app/views/shortened_urls/index.html.erb
@@ -5,7 +5,7 @@
 <table>
   <thead>
     <tr>
-      <th>Uid</th>
+      <th>Short url</th>
       <th>Original url</th>
       <th>Redirect count</th>
       <th colspan="3"></th>
@@ -15,8 +15,8 @@
   <tbody>
     <% @shortened_urls.each do |shortened_url| %>
       <tr>
-        <td><%= shortened_url.uid %></td>
-        <td><%= shortened_url.original_url %></td>
+        <td><%= link_to shortened_url.short_url, shortened_url.short_url, target: "_blank" %></td>
+        <td><%= link_to shortened_url.original_url, shortened_url.original_url, target: "_blank"  %></td>
         <td><%= shortened_url.redirect_count %></td>
         <td><%= link_to 'Show', shortened_url %></td>
       </tr>

--- a/app/views/shortened_urls/show.html.erb
+++ b/app/views/shortened_urls/show.html.erb
@@ -1,13 +1,13 @@
 <p id="notice"><%= notice %></p>
 
 <p>
-  <strong>Uid:</strong>
-  <%= @shortened_url.uid %>
+  <strong>Short url:</strong>
+  <%= link_to @shortened_url.short_url, @shortened_url.short_url, target: "_blank"  %>
 </p>
 
 <p>
   <strong>Original url:</strong>
-  <%= @shortened_url.original_url %>
+  <%= link_to @shortened_url.original_url, @shortened_url.original_url, target: "_blank"  %>
 </p>
 
 <p>

--- a/spec/views/shortened_urls/index.html.erb_spec.rb
+++ b/spec/views/shortened_urls/index.html.erb_spec.rb
@@ -4,24 +4,16 @@ require 'rails_helper'
 
 RSpec.describe 'shortened_urls/index', type: :view do
   before(:each) do
-    assign(:shortened_urls, [
-             ShortenedUrl.create!(
-               uid: 'Uid',
-               original_url: 'Original Url',
-               redirect_count: 2
-             ),
-             ShortenedUrl.create!(
-               uid: 'Uid',
-               original_url: 'Original Url',
-               redirect_count: 2
-             )
-           ])
+    assign(:shortened_urls, [shortened_url1, shortened_url2])
   end
+  let(:shortened_url1) { create(:shortened_url) }
+  let(:shortened_url2) { create(:shortened_url) }
 
   it 'renders a list of shortened_urls' do
     render
-    assert_select 'tr>td', text: 'Uid'.to_s, count: 2
-    assert_select 'tr>td', text: 'Original Url'.to_s, count: 2
-    assert_select 'tr>td', text: 2.to_s, count: 2
+    assert_select 'a[href=?]', shortened_url1.short_url, count: 1
+    assert_select 'a[href=?]', shortened_url2.short_url, count: 1
+    assert_select 'a[href=?]', shortened_url1.original_url, count: 1
+    assert_select 'a[href=?]', shortened_url2.original_url, count: 1
   end
 end

--- a/spec/views/shortened_urls/show.html.erb_spec.rb
+++ b/spec/views/shortened_urls/show.html.erb_spec.rb
@@ -4,17 +4,18 @@ require 'rails_helper'
 
 RSpec.describe 'shortened_urls/show', type: :view do
   before(:each) do
-    @shortened_url = assign(:shortened_url, ShortenedUrl.create!(
-                                              uid: 'Uid',
-                                              original_url: 'Original Url',
-                                              redirect_count: 2
-                                            ))
+    @shortened_url = assign(:shortened_url, shortened_url)
+  end
+  let(:shortened_url) do
+    ShortenedUrl.create!(
+      uid: 'Uid', original_url: 'https://www.example.com', redirect_count: 2
+    )
   end
 
   it 'renders attributes in <p>' do
     render
-    expect(rendered).to match(/Uid/)
-    expect(rendered).to match(/Original Url/)
-    expect(rendered).to match(/2/)
+    expect(rendered).to match(/#{shortened_url.short_url}/)
+    expect(rendered).to match(/#{shortened_url.original_url}/)
+    expect(rendered).to match(/#{shortened_url.redirect_count}/)
   end
 end


### PR DESCRIPTION
The user wont gain anything from seeing the uid on its own. The short_url
    is what they can for.