### PR TITLE
Add association between User and ShortenedUrls

### DIFF
--- a/app/controllers/shortened_urls_controller.rb
+++ b/app/controllers/shortened_urls_controller.rb
@@ -3,6 +3,7 @@
 class ShortenedUrlsController < ApplicationController
   # before_action :authenticate_user!, except: :redirect
 
+  # GET /:id
   def redirect
     @shortened_url = ShortenedUrl.find_by_uid(params[:id])
 
@@ -29,15 +30,15 @@ class ShortenedUrlsController < ApplicationController
 
   # POST /shortened_urls or /shortened_urls.json
   def create
-    @shortened_url = ShortenedUrl.new(shortened_url_params)
+    initialize_shortened_url
 
     respond_to do |format|
       if shortened_url.save
-        format.html { redirect_to @shortened_url, notice: 'Shortened url was successfully created.' }
-        format.json { render :show, status: :created, location: @shortened_url }
+        format.html { redirect_to shortened_url, notice: 'Shortened url was successfully created.' }
+        format.json { render :show, status: :created, location: shortened_url }
       else
         format.html { render :new, status: :unprocessable_entity }
-        format.json { render json: @shortened_url.errors, status: :unprocessable_entity }
+        format.json { render json: shortened_url.errors, status: :unprocessable_entity }
       end
     end
   end
@@ -55,5 +56,11 @@ class ShortenedUrlsController < ApplicationController
     shortened_url.update(redirect_count: shortened_url.redirect_count + 1)
 
     redirect_to shortened_url.original_url, status: 301
+  end
+
+  def initialize_shortened_url
+    @shortened_url = ShortenedUrl.new(
+      shortened_url_params.merge(user: User.first)
+    )
   end
 end

--- a/app/models/shortened_url.rb
+++ b/app/models/shortened_url.rb
@@ -3,6 +3,8 @@
 class ShortenedUrl < ApplicationRecord
   after_initialize :init_uid
 
+  belongs_to :user
+
   validates :uid, :original_url, presence: true
 
   def short_url

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,6 @@
 class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+  has_many :shortened_urls
 end

--- a/db/migrate/20210501182224_add_user_to_shortened_url.rb
+++ b/db/migrate/20210501182224_add_user_to_shortened_url.rb
@@ -1,0 +1,5 @@
+class AddUserToShortenedUrl < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :shortened_urls, :user, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_01_172839) do
+ActiveRecord::Schema.define(version: 2021_05_01_182224) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,7 +21,9 @@ ActiveRecord::Schema.define(version: 2021_05_01_172839) do
     t.integer "redirect_count", default: 0
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "user_id"
     t.index ["uid"], name: "index_shortened_urls_on_uid"
+    t.index ["user_id"], name: "index_shortened_urls_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
-FactoryBot.create_list(:user, 5)
+users = FactoryBot.create_list(:user, 5)
 
 (0..9).each do |i|
   FactoryBot.create(
     :shortened_url,
-    uid: "url-#{i + 1}"
+    uid: "url-#{i + 1}",
+    user: users.sample
   )
 end

--- a/spec/factories/shortened_urls.rb
+++ b/spec/factories/shortened_urls.rb
@@ -3,5 +3,6 @@
 FactoryBot.define do
   factory :shortened_url do
     original_url { "https://www.example.com/#{SecureRandom.uuid}" }
+    user { User.last || create(:user) }
   end
 end

--- a/spec/models/shortened_url_spec.rb
+++ b/spec/models/shortened_url_spec.rb
@@ -28,6 +28,10 @@ RSpec.describe ShortenedUrl, type: :model do
     end
   end
 
+  describe 'Associations' do
+    it { is_expected.to belong_to :user }
+  end
+
   describe 'Validations' do
     it { is_expected.to validate_presence_of :uid }
     it { is_expected.to validate_presence_of :original_url }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3,5 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'Associations' do
+    it { is_expected.to have_many :shortened_urls }
+  end
 end

--- a/spec/requests/shortened_urls/create_spec.rb
+++ b/spec/requests/shortened_urls/create_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe '/shortened_urls', type: :request do
       }
     end
 
+    before { create(:user) }
+
     context 'with valid parameters' do
       let(:shortened_url_created) { ShortenedUrl.last }
 

--- a/spec/views/shortened_urls/show.html.erb_spec.rb
+++ b/spec/views/shortened_urls/show.html.erb_spec.rb
@@ -6,11 +6,7 @@ RSpec.describe 'shortened_urls/show', type: :view do
   before(:each) do
     @shortened_url = assign(:shortened_url, shortened_url)
   end
-  let(:shortened_url) do
-    ShortenedUrl.create!(
-      uid: 'Uid', original_url: 'https://www.example.com', redirect_count: 2
-    )
-  end
+  let(:shortened_url) { create(:shortened_url) }
 
   it 'renders attributes in <p>' do
     render


### PR DESCRIPTION
* A User can have many ShortenedUrls
* A ShortenedUrl must have a User

This is half a job atm. Seeds and specs are valid. But the still does
not authenticate that a user is signed in, and so we cannot safely
assume there is a `current_user` to assign the url to. For the time
being to avoid validations the Create actions simple fetches a User,
basically at random.

My next PR will authenticate_user on all but the redirect action. This
will cause quite a few spec changes. Once that is merged and ready we
can easily limit the URLs visible by `current_user.shortened_urls`,
rather than `ShortenedUser.all'

Obviously if this was in production I would have added a feature toggle
and or figured out smaller PRs to enabled effective code review.