### PR TITLE
Require authentication on all but redirect

### DIFF
--- a/app/controllers/shortened_urls_controller.rb
+++ b/app/controllers/shortened_urls_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ShortenedUrlsController < ApplicationController
-  # before_action :authenticate_user!, except: :redirect
+  before_action :authenticate_user!, except: :redirect
 
   # GET /:id
   def redirect

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,6 +7,8 @@ require File.expand_path('../config/environment', __dir__)
 
 require 'support/factory_bot'
 require 'support/shoulda_matchers'
+require 'shared_contexts'
+require 'shared_examples'
 
 # Prevent database truncation if the environment is production
 abort('The Rails environment is in production mode!') if Rails.env.production?
@@ -25,6 +27,8 @@ end
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
+
+  config.include Warden::Test::Helpers, type: :request
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false

--- a/spec/requests/shortened_urls/create_spec.rb
+++ b/spec/requests/shortened_urls/create_spec.rb
@@ -13,67 +13,73 @@ RSpec.describe '/shortened_urls', type: :request do
       }
     end
 
-    before { create(:user) }
+    include_examples 'user not signed in so redirect'
 
-    context 'with valid parameters' do
-      let(:shortened_url_created) { ShortenedUrl.last }
+    context 'when user is signed in' do
+      include_context 'api request authentication helper methods'
+      include_context 'api request global before and after hooks'
+      before(:each) { sign_in }
 
-      it 'creates a new ShortenedUrl' do
-        expect { subject }.to change(ShortenedUrl, :count).by(1)
+      context 'with valid parameters' do
+        let(:shortened_url_created) { ShortenedUrl.last }
+
+        it 'creates a new ShortenedUrl' do
+          expect { subject }.to change(ShortenedUrl, :count).by(1)
+        end
+
+        it 'redirects to the created shortened_url' do
+          subject
+
+          expect(response).to redirect_to(
+            shortened_url_url(shortened_url_created)
+          )
+        end
+
+        it 'sets the expected shortened_url attributes' do
+          subject
+
+          expect(shortened_url_created.original_url).to eq 'https://example.com'
+          expect(shortened_url_created.redirect_count).to eq 0
+        end
+
+        context 'with uid and redirect_count given' do
+          let(:params) do
+            {
+              shortened_url: {
+                original_url: 'https://example.com',
+                uid: 'uid-given',
+                redirect_count: '77'
+              }
+            }
+          end
+
+          it 'does not use the uid or redirect_count given' do
+            subject
+
+            expect(shortened_url_created.redirect_count).to eq 0
+            expect(shortened_url_created.uid).to_not eq 77
+          end
+        end
       end
 
-      it 'redirects to the created shortened_url' do
-        subject
-
-        expect(response).to redirect_to(
-          shortened_url_url(shortened_url_created)
-        )
-      end
-
-      it 'sets the expected shortened_url attributes' do
-        subject
-
-        expect(shortened_url_created.original_url).to eq 'https://example.com'
-        expect(shortened_url_created.redirect_count).to eq 0
-      end
-
-      context 'with uid and redirect_count given' do
+      context 'with invalid parameters' do
         let(:params) do
           {
             shortened_url: {
-              original_url: 'https://example.com',
-              uid: 'uid-given',
-              redirect_count: '77'
+              someting_random: true
             }
           }
         end
 
-        it 'does not use the uid or redirect_count given' do
+        it 'does not create a new ShortenedUrl' do
+          expect { subject }.to change(ShortenedUrl, :count).by(0)
+        end
+
+        it 'renders an unsuccessful response' do
           subject
 
-          expect(shortened_url_created.redirect_count).to eq 0
-          expect(shortened_url_created.uid).to_not eq 77
+          expect(response).to_not be_successful
         end
-      end
-    end
-
-    context 'with invalid parameters' do
-      let(:params) do
-        {
-          shortened_url: {
-            someting_random: true
-          }
-        }
-      end
-
-      it 'does not create a new ShortenedUrl' do
-        expect { subject }.to change(ShortenedUrl, :count).by(0)
-      end
-
-      it 'renders an unsuccessful response' do
-        subject
-
-        expect(response).to_not be_successful
       end
     end
   end

--- a/spec/requests/shortened_urls/index_spec.rb
+++ b/spec/requests/shortened_urls/index_spec.rb
@@ -4,11 +4,21 @@ require 'rails_helper'
 
 RSpec.describe '/shortened_urls', type: :request do
   describe 'GET /index' do
+    subject { get shortened_urls_url }
     before { create_list(:shortened_url, 5) }
 
-    it 'renders a successful response' do
-      get shortened_urls_url
-      expect(response).to be_successful
+    include_examples 'user not signed in so redirect'
+
+    context 'when user is signed in' do
+      include_context 'api request authentication helper methods'
+      include_context 'api request global before and after hooks'
+      before(:each) { sign_in }
+
+      it 'renders a successful response' do
+        subject
+
+        expect(response).to be_successful
+      end
     end
   end
 end

--- a/spec/requests/shortened_urls/new_spec.rb
+++ b/spec/requests/shortened_urls/new_spec.rb
@@ -4,9 +4,19 @@ require 'rails_helper'
 
 RSpec.describe '/shortened_urls', type: :request do
   describe 'GET /new' do
-    it 'renders a successful response' do
-      get new_shortened_url_url
-      expect(response).to be_successful
+    subject { get new_shortened_url_url }
+
+    include_examples 'user not signed in so redirect'
+
+    context 'when user is signed in' do
+      include_context 'api request authentication helper methods'
+      include_context 'api request global before and after hooks'
+      it 'renders a successful response' do
+        sign_in
+
+        subject
+        expect(response).to be_successful
+      end
     end
   end
 end

--- a/spec/requests/shortened_urls/redirect_spec.rb
+++ b/spec/requests/shortened_urls/redirect_spec.rb
@@ -7,49 +7,104 @@ RSpec.describe '/:id', type: :request do
     subject { get shortened_url_redirect_path(id: given_id_param) }
     let(:given_id_param) { 'abc123' }
 
-    context 'on success' do
-      let!(:related_url) { create(:shortened_url, uid: given_id_param) }
+    context 'when signed in' do
+      include_context 'api request authentication helper methods'
+      include_context 'api request global before and after hooks'
+      before(:each) { sign_in }
 
-      it 'redirects the request tot he urls original_url' do
-        expect(subject).to redirect_to related_url.original_url
-      end
-
-      it 'should return 301 status' do
-        subject
-
-        expect(response.status).to eq 301
-      end
-
-      it 'increments redirect_count on the related url by 1' do
-        expect do
-          subject
-          related_url.reload
-        end.to change(related_url, :redirect_count)
-          .from(0).to(1)
-      end
-
-      context 'other urls present containing only different capitalisation' do
-        let!(:similar_url) { create(:shortened_url) }
+      context 'on success' do
+        let!(:related_url) { create(:shortened_url, uid: given_id_param) }
 
         it 'redirects the request tot he urls original_url' do
           expect(subject).to redirect_to related_url.original_url
         end
 
-        it 'does not change the similar urls redirect_count' do
+        it 'should return 301 status' do
+          subject
+
+          expect(response.status).to eq 301
+        end
+
+        it 'increments redirect_count on the related url by 1' do
           expect do
             subject
-            similar_url.reload
-          end.to_not change(related_url, :redirect_count)
+            related_url.reload
+          end.to change(related_url, :redirect_count)
+            .from(0).to(1)
+        end
+
+        context 'other urls present containing only different capitalisation' do
+          let!(:similar_url) { create(:shortened_url) }
+
+          it 'redirects the request tot he urls original_url' do
+            expect(subject).to redirect_to related_url.original_url
+          end
+
+          it 'does not change the similar urls redirect_count' do
+            expect do
+              subject
+              similar_url.reload
+            end.to_not change(related_url, :redirect_count)
+          end
+        end
+      end
+
+      context 'on failure' do
+        context 'shortened_url does not exist' do
+          it 'should return 404 status' do
+            subject
+
+            expect(response.status).to eq 404
+          end
         end
       end
     end
 
-    context 'on failure' do
-      context 'shortened_url does not exist' do
-        it 'should return 304 status' do
+    context 'when not signed in' do
+      context 'on success' do
+        let!(:related_url) { create(:shortened_url, uid: given_id_param) }
+
+        it 'redirects the request tot he urls original_url' do
+          expect(subject).to redirect_to related_url.original_url
+        end
+
+        it 'should return 301 status' do
           subject
 
-          expect(response.status).to eq 404
+          expect(response.status).to eq 301
+        end
+
+        it 'increments redirect_count on the related url by 1' do
+          expect do
+            subject
+            related_url.reload
+          end.to change(related_url, :redirect_count)
+            .from(0).to(1)
+        end
+
+        context 'other urls present containing only different capitalisation' do
+          let!(:similar_url) { create(:shortened_url) }
+
+          it 'redirects the request tot he urls original_url' do
+            expect(subject).to redirect_to related_url.original_url
+          end
+
+          it 'does not change the similar urls redirect_count' do
+            expect do
+              subject
+              similar_url.reload
+            end.to_not change(related_url, :redirect_count)
+          end
+        end
+      end
+
+      context 'on failure' do
+        context 'shortened_url does not exist' do
+          it 'should return 404 status' do
+            subject
+
+            expect(response.status).to eq 404
+          end
         end
       end
     end

--- a/spec/requests/shortened_urls/show_spec.rb
+++ b/spec/requests/shortened_urls/show_spec.rb
@@ -4,11 +4,20 @@ require 'rails_helper'
 
 RSpec.describe '/shortened_urls', type: :request do
   describe 'GET /show' do
+    subject { get shortened_url_url(shortened_url) }
     let(:shortened_url) { create(:shortened_url) }
 
-    it 'renders a successful response' do
-      get shortened_url_url(shortened_url)
-      expect(response).to be_successful
+    include_examples 'user not signed in so redirect'
+
+    context 'when user is signed in' do
+      include_context 'api request authentication helper methods'
+      include_context 'api request global before and after hooks'
+      it 'renders a successful response' do
+        sign_in
+
+        subject
+        expect(response).to be_successful
+      end
     end
   end
 end

--- a/spec/shared_contexts.rb
+++ b/spec/shared_contexts.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'shared_contexts'
+
+RSpec.shared_context 'api request global before and after hooks' do
+  before(:each) do
+    Warden.test_mode!
+  end
+
+  after(:each) do
+    Warden.test_reset!
+  end
+end
+
+RSpec.shared_context 'api request authentication helper methods' do
+  let(:user) { create(:user) }
+
+  def sign_in
+    login_as(user, scope: :user)
+  end
+
+  def sign_out
+    logout(:user)
+  end
+end

--- a/spec/shared_examples.rb
+++ b/spec/shared_examples.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'shared_contexts'
+
+RSpec.shared_examples 'user not signed in so redirect' do
+  context 'when user is not signed in' do
+    it 'renders a not successful response' do
+      subject
+
+      expect(response).to_not be_successful
+    end
+
+    it 'should be redirecting to sing_in' do
+      subject
+
+      expect(response.code).to eq('302')
+      expect(response).to redirect_to(user_session_path)
+    end
+  end
+end


### PR DESCRIPTION
This will require a user to be registered and signed in before they can
see or create ShortenedUrls.