### PR TITLE
Only allow users to see their own URLs

### DIFF
--- a/app/controllers/shortened_urls_controller.rb
+++ b/app/controllers/shortened_urls_controller.rb
@@ -2,25 +2,23 @@
 
 class ShortenedUrlsController < ApplicationController
   before_action :authenticate_user!, except: :redirect
+  rescue_from ActiveRecord::RecordNotFound, with: :render404
 
   # GET /:id
   def redirect
-    @shortened_url = ShortenedUrl.find_by_uid(params[:id])
+    @shortened_url = ShortenedUrl.find_by_uid!(params[:id])
 
-    redirect_and_increment_counter and return if shortened_url.present?
-
-    render file: "#{Rails.root}/public/404.html",
-           status: 404
+    redirect_and_increment_counter
   end
 
   # GET /shortened_urls or /shortened_urls.json
   def index
-    @shortened_urls = ShortenedUrl.all
+    @shortened_urls = current_user.shortened_urls.all
   end
 
   # GET /shortened_urls/1 or /shortened_urls/1.json
   def show
-    @shortened_url = ShortenedUrl.find(params[:id])
+    @shortened_url = current_user.shortened_urls.find(params[:id])
   end
 
   # GET /shortened_urls/new
@@ -59,8 +57,11 @@ class ShortenedUrlsController < ApplicationController
   end
 
   def initialize_shortened_url
-    @shortened_url = ShortenedUrl.new(
-      shortened_url_params.merge(user: User.first)
-    )
+    @shortened_url = current_user.shortened_urls.new(shortened_url_params)
+  end
+
+  def render404
+    render file: "#{Rails.root}/public/404.html",
+           status: 404
   end
 end

--- a/app/views/shortened_urls/index.html.erb
+++ b/app/views/shortened_urls/index.html.erb
@@ -1,4 +1,4 @@
-<h1>Shortened Urls</h1>
+<h1>Your Shortened Urls</h1>
 
 <table>
   <thead>

--- a/spec/requests/shortened_urls/create_spec.rb
+++ b/spec/requests/shortened_urls/create_spec.rb
@@ -35,11 +35,12 @@ RSpec.describe '/shortened_urls', type: :request do
           )
         end
 
-        it 'sets the expected shortened_url attributes' do
+        it 'sets the expected shortened_url attributes and owned by the user' do
           subject
 
           expect(shortened_url_created.original_url).to eq 'https://example.com'
           expect(shortened_url_created.redirect_count).to eq 0
+          expect(shortened_url_created.user).to eq user
         end
 
         context 'with uid and redirect_count given' do

--- a/spec/requests/shortened_urls/index_spec.rb
+++ b/spec/requests/shortened_urls/index_spec.rb
@@ -5,7 +5,6 @@ require 'rails_helper'
 RSpec.describe '/shortened_urls', type: :request do
   describe 'GET /index' do
     subject { get shortened_urls_url }
-    before { create_list(:shortened_url, 5) }
 
     include_examples 'user not signed in so redirect'
 

--- a/spec/requests/shortened_urls/show_spec.rb
+++ b/spec/requests/shortened_urls/show_spec.rb
@@ -5,18 +5,46 @@ require 'rails_helper'
 RSpec.describe '/shortened_urls', type: :request do
   describe 'GET /show' do
     subject { get shortened_url_url(shortened_url) }
-    let(:shortened_url) { create(:shortened_url) }
+    let(:shortened_url) { create(:shortened_url, user: create(:user)) }
 
     include_examples 'user not signed in so redirect'
 
     context 'when user is signed in' do
       include_context 'api request authentication helper methods'
       include_context 'api request global before and after hooks'
-      it 'renders a successful response' do
+      before do
         sign_in
+      end
 
-        subject
-        expect(response).to be_successful
+      context 'the shortened_url exists' do
+        context 'and belongs to the current_user' do
+          let(:shortened_url) { create(:shortened_url, user: user) }
+
+          it 'renders a successful response' do
+            subject
+            expect(response).to be_successful
+          end
+        end
+
+        context 'but does not belong to the current_user' do
+          it 'should return unsuccessful 404 status' do
+            subject
+
+            expect(response).to_not be_successful
+            expect(response.status).to eq 404
+          end
+        end
+      end
+
+      context 'the shortened_url does not exist' do
+        subject { get shortened_url_url(id: 'does-not-exist') }
+
+        it 'should return unsuccessful 404 status' do
+          subject
+
+          expect(response).to_not be_successful
+          expect(response.status).to eq 404
+        end
       end
     end
   end


### PR DESCRIPTION
This completes the web pages and makes the sight a little easier to use
since you only see your own links.

The specs for these are not ideal. I clearly have a lot to learn around
how to text the HTML/DOM returned. The glaring flaw here is the index
action. I don't test that the user can only see their own URLs. If I had
a code base to work from I could probably figure it out but the only
references I have are google, which hasn't been much help, and my work
stuff. Which is primarily APIs, so we can easily test the JSON. If I was
part of a team i would definitely be asking for assistance at this point
and would definitely not put this up for code_review.