### PR TITLE
Validate the original_url contains a protocol

### DIFF
--- a/app/models/shortened_url.rb
+++ b/app/models/shortened_url.rb
@@ -6,6 +6,11 @@ class ShortenedUrl < ApplicationRecord
   belongs_to :user
 
   validates :uid, :original_url, presence: true
+  validates :original_url,
+            format: {
+              with: URI::DEFAULT_PARSER.make_regexp(%w[http https]),
+              message: 'The protocol must be provided (http, https)'
+            }
 
   def short_url
     @short_url ||= ENV['SERVICE_URL'] + uid

--- a/spec/models/shortened_url_spec.rb
+++ b/spec/models/shortened_url_spec.rb
@@ -35,6 +35,53 @@ RSpec.describe ShortenedUrl, type: :model do
   describe 'Validations' do
     it { is_expected.to validate_presence_of :uid }
     it { is_expected.to validate_presence_of :original_url }
+
+    describe 'original_url' do
+      let(:valid_urls) do
+        %w[
+          http://www.example.com
+          https://www.example.com
+          http://example.com
+          https://example.com
+          http://localhost:3000
+          http://fake-url.com
+        ]
+      end
+      let(:invalid_urls) do
+        %w[
+          www.example.com
+          www.example.com
+          example.com
+          example.com
+          localhost:3000
+          fake-url.com
+        ]
+      end
+
+      it 'ensure HTTP or HTTPS protocols are provided' do
+        valid_urls.each do |url|
+          expect(build(:shortened_url, original_url: url).valid?).to eq true
+        end
+        invalid_urls.each do |url|
+          expect(build(:shortened_url, original_url: url).valid?).to eq false
+        end
+      end
+
+      describe 'validation error message' do
+        subject do
+          build(:shortened_url, original_url: 'protocol-less.com')
+            .tap(&:valid?)
+            .errors
+            .messages
+        end
+
+        it 'returns the expected message' do
+          expect(subject[:original_url].first).to eq(
+            'The protocol must be provided (http, https)'
+          )
+        end
+      end
+    end
   end
 
   describe '#short_url' do


### PR DESCRIPTION
URL validations is biiig task, and is very easy to over restrict. In
this case the only thing we need is for a protocol and then the site
will be able to correct link the user to the url. It is then on them to
ensure they provide a link actually works.