### PR TITLE
Add Redirects model

### DIFF
--- a/app/models/redirect.rb
+++ b/app/models/redirect.rb
@@ -1,0 +1,3 @@
+class Redirect < ApplicationRecord
+  belongs_to :shortened_url
+end

--- a/app/models/shortened_url.rb
+++ b/app/models/shortened_url.rb
@@ -4,6 +4,7 @@ class ShortenedUrl < ApplicationRecord
   after_initialize :init_uid
 
   belongs_to :user
+  has_many :redirects
 
   validates :uid, :original_url, presence: true
   validates :original_url,

--- a/db/migrate/20210514161243_create_redirects.rb
+++ b/db/migrate/20210514161243_create_redirects.rb
@@ -1,0 +1,9 @@
+class CreateRedirects < ActiveRecord::Migration[6.1]
+  def change
+    create_table :redirects do |t|
+      t.references :shortened_url, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_01_182224) do
+ActiveRecord::Schema.define(version: 2021_05_14_161243) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "redirects", force: :cascade do |t|
+    t.bigint "shortened_url_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["shortened_url_id"], name: "index_redirects_on_shortened_url_id"
+  end
 
   create_table "shortened_urls", force: :cascade do |t|
     t.string "uid"
@@ -38,4 +45,5 @@ ActiveRecord::Schema.define(version: 2021_05_01_182224) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "redirects", "shortened_urls"
 end

--- a/spec/factories/redirects.rb
+++ b/spec/factories/redirects.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :redirect do
+    shortened_url { nil }
+  end
+end

--- a/spec/models/redirect_spec.rb
+++ b/spec/models/redirect_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe Redirect, type: :model do
+  describe 'Associations' do
+    it { is_expected.to belong_to :shortened_url }
+  end
+end

--- a/spec/models/shortened_url_spec.rb
+++ b/spec/models/shortened_url_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe ShortenedUrl, type: :model do
 
   describe 'Associations' do
     it { is_expected.to belong_to :user }
+    it { is_expected.to have_many :redirects }
   end
 
   describe 'Validations' do


### PR DESCRIPTION
A shortened_url can have many redirects. This will later be used to
store when a short url is used.